### PR TITLE
Update admin mobile theme to match client palette

### DIFF
--- a/movile/movile_admin/lib/constants/app_constants.dart
+++ b/movile/movile_admin/lib/constants/app_constants.dart
@@ -3,12 +3,12 @@ import 'package:flutter/material.dart';
 
 class AppConstants {
   // Colores principales
-  static const Color primaryColor = Color(0xff4a6741); // Verde oscuro principal
-  static const Color secondaryColor = Color(0xffb4debf); // Verde claro
-  static const Color accentColor = Color(0xffe8e5dc); // Beige claro
+  static const Color primaryColor = Color(0xFF00C853); // Verde principal (coincide con cliente)
+  static const Color secondaryColor = Color(0xFFB9F6CA); // Verde claro complementario
+  static const Color accentColor = Color(0xfff5f5f5); // Fondo neutro claro
   static const Color textDarkColor = Color(0xff343b45); // Texto oscuro
   static const Color textLightColor = Color(0xff626762); // Texto gris
-  static const Color backgroundColor = Color(0xffe8e5dc); // Fondo beige
+  static const Color backgroundColor = Colors.white; // Fondo blanco
 
   // Configuración del tema
   static const String appTitle = 'Admin - Inventario';

--- a/movile/movile_admin/lib/main.dart
+++ b/movile/movile_admin/lib/main.dart
@@ -1,5 +1,6 @@
 // lib/main.dart
 import 'package:flutter/material.dart';
+import 'package:movile_admin/constants/app_constants.dart';
 import 'package:movile_admin/pages/check_email_page.dart';
 import 'package:movile_admin/pages/login_page.dart';
 import 'package:movile_admin/pages/recover_password.dart';
@@ -80,7 +81,14 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Admin - Inventario',
       debugShowCheckedModeBanner: false,
-      theme: ThemeData(primarySwatch: Colors.green, useMaterial3: true),
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: AppConstants.primaryColor,
+          background: AppConstants.backgroundColor,
+        ),
+        scaffoldBackgroundColor: AppConstants.backgroundColor,
+        useMaterial3: true,
+      ),
       initialRoute: '/login',
       routes: {
         '/login': (context) => const LoginPage(),
@@ -165,7 +173,7 @@ class _MainScreenState extends State<MainScreen> {
           // Otras secciones todavía no implementadas
           return MaterialPageRoute(
             builder: (_) => Scaffold(
-              backgroundColor: const Color(0xffe8e5dc),
+              backgroundColor: AppConstants.backgroundColor,
               body: Center(
                 child: Text(
                   'Sección $index en construcción',
@@ -194,7 +202,7 @@ class _MainScreenState extends State<MainScreen> {
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _selectedIndex,
         type: BottomNavigationBarType.fixed,
-        backgroundColor: const Color(0xffb4debf), // Verde claro
+        backgroundColor: AppConstants.backgroundColor,
         selectedItemColor: const Color(
           0xff343b45,
         ), // Texto oscuro al seleccionar

--- a/movile/movile_admin/lib/screens/product_batches.dart
+++ b/movile/movile_admin/lib/screens/product_batches.dart
@@ -1,5 +1,6 @@
 // lib/screens/product_batches.dart
 import 'package:flutter/material.dart';
+import 'package:movile_admin/constants/app_constants.dart';
 import '../models/product.dart';
 
 class ProductBatchesScreen extends StatefulWidget {
@@ -37,9 +38,9 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
     }).toList();
 
     return Scaffold(
-      backgroundColor: const Color(0xffe8e5dc),
+      backgroundColor: AppConstants.backgroundColor,
       appBar: AppBar(
-        backgroundColor: const Color(0xffb4debf), // Verde claro
+        backgroundColor: AppConstants.secondaryColor, // Verde claro
         elevation: 0,
         title: Text(
           'Lotes de: ${product.name}',
@@ -66,18 +67,18 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
                 hintText: "Buscar lote (ID, código, fecha)...",
                 prefixIcon: const Icon(Icons.search, color: Color(0xff626762)),
                 filled: true,
-                fillColor: const Color.fromARGB(255, 255, 255, 255),
+                fillColor: AppConstants.backgroundColor,
                 contentPadding: const EdgeInsets.symmetric(
                   horizontal: 12,
                   vertical: 0,
                 ),
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xffb4debf)),
+                  borderSide: const BorderSide(color: AppConstants.secondaryColor),
                 ),
                 focusedBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xff626762)),
+                  borderSide: const BorderSide(color: AppConstants.primaryColor),
                 ),
               ),
             ),
@@ -113,7 +114,9 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
                     decoration: BoxDecoration(
                       color: Colors.white,
                       borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: const Color(0xffd4e6d7)),
+                      border: Border.all(
+                        color: AppConstants.secondaryColor.withOpacity(0.6),
+                      ),
                       boxShadow: [
                         BoxShadow(
                           color: Colors.black.withOpacity(0.05),
@@ -186,7 +189,7 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
                         Text(
                           "\$${b.price.toStringAsFixed(0)}",
                           style: const TextStyle(
-                            color: Colors.green,
+                            color: AppConstants.primaryColor,
                             fontWeight: FontWeight.bold,
                             fontSize: 15,
                           ),

--- a/movile/movile_admin/lib/screens/product_detail.dart
+++ b/movile/movile_admin/lib/screens/product_detail.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:movile_admin/constants/app_constants.dart';
 import '../models/product.dart';
 import '../models/batch.dart';
 
@@ -40,9 +41,9 @@ class ProductDetailScreen extends StatelessWidget {
     final Batch batch = args['batch'] as Batch;
 
     return Scaffold(
-      backgroundColor: const Color(0xffe8e5dc),
+      backgroundColor: AppConstants.backgroundColor,
       appBar: AppBar(
-        backgroundColor: const Color(0xffb4debf), // Verde claro
+        backgroundColor: AppConstants.secondaryColor, // Verde claro
         elevation: 0,
         title: Text(
           'Detalle - ${product.name}',

--- a/movile/movile_admin/lib/screens/product_list.dart
+++ b/movile/movile_admin/lib/screens/product_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:movile_admin/constants/app_constants.dart';
 import '../models/product.dart';
 
 class ProductListScreen extends StatefulWidget {
@@ -56,14 +57,9 @@ class _ProductListScreenState extends State<ProductListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xffe8e5dc), // Fondo suave
+      backgroundColor: AppConstants.backgroundColor, // Fondo blanco
       appBar: AppBar(
-        backgroundColor: const Color.fromARGB(
-          215,
-          180,
-          222,
-          191,
-        ), // Verde claro principal
+        backgroundColor: AppConstants.secondaryColor,
         elevation: 0,
         title: const Text(
           'Productos',
@@ -89,18 +85,18 @@ class _ProductListScreenState extends State<ProductListScreen> {
                 hintText: "Buscar producto...",
                 prefixIcon: const Icon(Icons.search, color: Color(0xff626762)),
                 filled: true,
-                fillColor: const Color.fromARGB(255, 255, 255, 255),
+                fillColor: AppConstants.backgroundColor,
                 contentPadding: const EdgeInsets.symmetric(
                   horizontal: 12,
                   vertical: 0,
                 ),
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xffb4debf)),
+                  borderSide: const BorderSide(color: AppConstants.secondaryColor),
                 ),
                 focusedBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xff626762)),
+                  borderSide: const BorderSide(color: AppConstants.primaryColor),
                 ),
               ),
             ),
@@ -126,8 +122,8 @@ class _ProductListScreenState extends State<ProductListScreen> {
                     ),
                   ),
                   selected: isSelected,
-                  selectedColor: const Color(0xff626762),
-                  backgroundColor: const Color(0xffd4e6d7),
+                  selectedColor: AppConstants.primaryColor,
+                  backgroundColor: AppConstants.secondaryColor.withOpacity(0.5),
                   onSelected: (_) {
                     setState(() {
                       _selectedFilter = filter;
@@ -154,7 +150,7 @@ class _ProductListScreenState extends State<ProductListScreen> {
                     decoration: BoxDecoration(
                       color: Colors.white,
                       borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: const Color(0xffd4e6d7)),
+                      border: Border.all(color: AppConstants.secondaryColor.withOpacity(0.6)),
                       boxShadow: [
                         BoxShadow(
                           color: Colors.black.withOpacity(0.05),
@@ -180,7 +176,7 @@ class _ProductListScreenState extends State<ProductListScreen> {
                             errorBuilder: (_, __, ___) => Container(
                               width: 100,
                               height: 100,
-                              color: const Color(0xffd4e6d7),
+                              color: AppConstants.secondaryColor.withOpacity(0.5),
                               child: const Icon(
                                 Icons.image,
                                 color: Color(0xff626762),
@@ -234,7 +230,7 @@ class _ProductListScreenState extends State<ProductListScreen> {
                                 Text(
                                   "\$${p.price.toStringAsFixed(0)}",
                                   style: const TextStyle(
-                                    color: Colors.green,
+                                    color: AppConstants.primaryColor,
                                     fontWeight: FontWeight.bold,
                                     fontSize: 15,
                                   ),
@@ -250,7 +246,7 @@ class _ProductListScreenState extends State<ProductListScreen> {
                             p.status,
                             style: TextStyle(
                               color: p.status.toLowerCase() == "activo"
-                                  ? Colors.green
+                                  ? AppConstants.primaryColor
                                   : Colors.red,
                               fontWeight: FontWeight.w600,
                             ),

--- a/movile/movile_admin/lib/services/navigation_service.dart
+++ b/movile/movile_admin/lib/services/navigation_service.dart
@@ -1,6 +1,7 @@
 // lib/services/navigation_service.dart
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:movile_admin/constants/app_constants.dart';
 import 'package:movile_admin/models/provider.dart' as model;
 import '../models/product.dart';
 import '../services/product_service.dart';
@@ -75,7 +76,7 @@ class NavigationService {
 
   static Widget _buildUnderConstructionScreen(int? sectionIndex) {
     return Scaffold(
-      backgroundColor: const Color(0xffe8e5dc),
+      backgroundColor: AppConstants.backgroundColor,
       body: Center(
         child: Text(
           'Sección ${sectionIndex ?? 'desconocida'} en construcción',


### PR DESCRIPTION
## Summary
- align the admin mobile color constants with the client application's green primary and white background
- refresh the theme configuration and key screens to use the updated palette consistently

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e20a081b5c8320b03ed2bda7116224