### PR TITLE
feat: unify admin palette with client design

### DIFF
--- a/movile/kajamart_movile/lib/admin/constants/app_constants.dart
+++ b/movile/kajamart_movile/lib/admin/constants/app_constants.dart
@@ -3,12 +3,12 @@ import 'package:flutter/material.dart';
 
 class AppConstants {
   // Colores principales
-  static const Color primaryColor = Color(0xff4a6741); // Verde oscuro principal
-  static const Color secondaryColor = Color(0xffb4debf); // Verde claro
-  static const Color accentColor = Color(0xffe8e5dc); // Beige claro
-  static const Color textDarkColor = Color(0xff343b45); // Texto oscuro
-  static const Color textLightColor = Color(0xff626762); // Texto gris
-  static const Color backgroundColor = Color(0xffe8e5dc); // Fondo beige
+  static const Color primaryColor = Color(0xFF00C853); // Verde brillante principal
+  static const Color secondaryColor = Color(0xFFE8F5E9); // Verde claro suave
+  static const Color accentColor = Color(0xFFF5F5F5); // Gris muy claro
+  static const Color textDarkColor = Color(0xFF1F1F1F); // Texto oscuro
+  static const Color textLightColor = Color(0xFF616161); // Texto gris
+  static const Color backgroundColor = Color(0xFFFFFFFF); // Fondo blanco
 
   // Configuración del tema
   static const String appTitle = 'Admin - Inventario';

--- a/movile/kajamart_movile/lib/admin/screens/admin_home.dart
+++ b/movile/kajamart_movile/lib/admin/screens/admin_home.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
-import 'provider_list.dart';
-import 'product_list.dart';
+import '../constants/app_constants.dart';
 import '../services/data_service.dart';
+import 'product_list.dart';
 import 'profile_screen.dart';
+import 'provider_list.dart';
 
 class AdminHomeScreen extends StatefulWidget {
   const AdminHomeScreen({super.key});
@@ -45,6 +46,7 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppConstants.backgroundColor,
       appBar: AppBar(
         title: Text(
           _titles[_selectedIndex],
@@ -53,7 +55,7 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
             fontWeight: FontWeight.bold,
           ),
         ),
-        backgroundColor: const Color(0xFF00C853),
+        backgroundColor: AppConstants.primaryColor,
         elevation: 0,
       ),
       body: _buildScreenContent(),
@@ -69,7 +71,7 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
             });
           }
         },
-        selectedItemColor: const Color(0xFF00C853),
+        selectedItemColor: AppConstants.primaryColor,
         unselectedItemColor: Colors.grey,
         items: const [
           BottomNavigationBarItem(

--- a/movile/kajamart_movile/lib/admin/screens/product_batches.dart
+++ b/movile/kajamart_movile/lib/admin/screens/product_batches.dart
@@ -1,5 +1,6 @@
 // lib/screens/product_batches.dart
 import 'package:flutter/material.dart';
+import '../constants/app_constants.dart';
 import '../models/product.dart';
 
 class ProductBatchesScreen extends StatefulWidget {
@@ -37,14 +38,14 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
     }).toList();
 
     return Scaffold(
-      backgroundColor: const Color.fromARGB(255, 255, 255, 255),
+      backgroundColor: AppConstants.backgroundColor,
       appBar: AppBar(
-        backgroundColor: const Color(0xffb4debf), // Verde claro
+        backgroundColor: AppConstants.secondaryColor,
         elevation: 0,
         title: Text(
           'Lotes de: ${product.name}',
-          style: const TextStyle(
-            color: Color(0xff343b45),
+          style: TextStyle(
+            color: AppConstants.textDarkColor,
             fontWeight: FontWeight.bold,
           ),
         ),
@@ -64,20 +65,21 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
               },
               decoration: InputDecoration(
                 hintText: "Buscar lote (ID, código, fecha)...",
-                prefixIcon: const Icon(Icons.search, color: Color(0xff626762)),
+                prefixIcon:
+                    Icon(Icons.search, color: AppConstants.textLightColor),
                 filled: true,
-                fillColor: const Color.fromARGB(255, 255, 255, 255),
+                fillColor: Colors.white,
                 contentPadding: const EdgeInsets.symmetric(
                   horizontal: 12,
                   vertical: 0,
                 ),
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xffb4debf)),
+                  borderSide: BorderSide(color: AppConstants.secondaryColor),
                 ),
                 focusedBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xff626762)),
+                  borderSide: BorderSide(color: AppConstants.textLightColor),
                 ),
               ),
             ),
@@ -86,9 +88,9 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 12),
             child: Text(
               'Producto ID: ${product.id}',
-              style: const TextStyle(
+              style: TextStyle(
                 fontWeight: FontWeight.bold,
-                color: Color(0xff343b45),
+                color: AppConstants.textDarkColor,
               ),
             ),
           ),
@@ -113,7 +115,9 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
                     decoration: BoxDecoration(
                       color: Colors.white,
                       borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: const Color(0xffd4e6d7)),
+                      border: Border.all(
+                        color: AppConstants.secondaryColor.withOpacity(0.6),
+                      ),
                       boxShadow: [
                         BoxShadow(
                           color: Colors.black.withOpacity(0.05),
@@ -128,26 +132,26 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
                       children: [
                         Text(
                           "ID Lote: ${b.idDetalle}",
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontWeight: FontWeight.bold,
                             fontSize: 15,
-                            color: Color(0xff343b45),
+                            color: AppConstants.textDarkColor,
                           ),
                         ),
                         const SizedBox(height: 4),
                         Text(
                           "Código: ${b.barcode}",
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 13,
-                            color: Color(0xff626762),
+                            color: AppConstants.textLightColor,
                           ),
                         ),
                         const SizedBox(height: 4),
                         Text(
                           "Vence: ${b.expiryDate.toIso8601String().split('T')[0]}",
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 13,
-                            color: Color(0xff626762),
+                            color: AppConstants.textLightColor,
                           ),
                         ),
                         const SizedBox(height: 4),
@@ -185,8 +189,8 @@ class _ProductBatchesScreenState extends State<ProductBatchesScreen> {
                         const SizedBox(height: 6),
                         Text(
                           "\$${b.price.toStringAsFixed(0)}",
-                          style: const TextStyle(
-                            color: Colors.green,
+                          style: TextStyle(
+                            color: AppConstants.primaryColor,
                             fontWeight: FontWeight.bold,
                             fontSize: 15,
                           ),

--- a/movile/kajamart_movile/lib/admin/screens/product_detail.dart
+++ b/movile/kajamart_movile/lib/admin/screens/product_detail.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../constants/app_constants.dart';
 import '../models/product.dart';
 import '../models/batch.dart';
 
@@ -15,16 +16,16 @@ class ProductDetailScreen extends StatelessWidget {
             width: 160,
             child: Text(
               label,
-              style: const TextStyle(
+              style: TextStyle(
                 fontWeight: FontWeight.bold,
-                color: Color(0xff343b45),
+                color: AppConstants.textDarkColor,
               ),
             ),
           ),
           Expanded(
             child: Text(
               value,
-              style: const TextStyle(color: Color(0xff626762)),
+              style: TextStyle(color: AppConstants.textLightColor),
             ),
           ),
         ],
@@ -40,14 +41,14 @@ class ProductDetailScreen extends StatelessWidget {
     final Batch batch = args['batch'] as Batch;
 
     return Scaffold(
-      backgroundColor: const Color(0xffe8e5dc),
+      backgroundColor: AppConstants.backgroundColor,
       appBar: AppBar(
-        backgroundColor: const Color(0xffb4debf), // Verde claro
+        backgroundColor: AppConstants.secondaryColor,
         elevation: 0,
         title: Text(
           'Detalle - ${product.name}',
-          style: const TextStyle(
-            color: Color(0xff343b45),
+          style: TextStyle(
+            color: AppConstants.textDarkColor,
             fontWeight: FontWeight.bold,
           ),
         ),
@@ -78,10 +79,10 @@ class ProductDetailScreen extends StatelessWidget {
                 child: Image.network(
                   product.imageUrl,
                   fit: BoxFit.cover,
-                  errorBuilder: (_, __, ___) => const Icon(
+                  errorBuilder: (_, __, ___) => Icon(
                     Icons.image,
                     size: 80,
-                    color: Color(0xff626762),
+                    color: AppConstants.textLightColor,
                   ),
                 ),
               ),

--- a/movile/kajamart_movile/lib/admin/screens/product_list.dart
+++ b/movile/kajamart_movile/lib/admin/screens/product_list.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../constants/app_constants.dart';
 import '../models/product.dart';
 
 class ProductListScreen extends StatefulWidget {
@@ -14,7 +15,7 @@ class _ProductListScreenState extends State<ProductListScreen> {
   String _selectedFilter = "Todos";
   String _searchQuery = "";
 
-  List<String> get filters => ["Todas", "Activos", "Inactivos", "Stock bajo"];
+  List<String> get filters => ["Todos", "Activos", "Inactivos", "Stock bajo"];
 
   List<Product> get filteredProducts {
     List<Product> list;
@@ -56,19 +57,14 @@ class _ProductListScreenState extends State<ProductListScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xffe8e5dc), // Fondo suave
+      backgroundColor: AppConstants.backgroundColor,
       appBar: AppBar(
-        backgroundColor: const Color.fromARGB(
-          215,
-          180,
-          222,
-          191,
-        ), // Verde claro principal
+        backgroundColor: AppConstants.secondaryColor,
         elevation: 0,
-        title: const Text(
+        title: Text(
           'Productos',
           style: TextStyle(
-            color: Color(0xff343b45),
+            color: AppConstants.textDarkColor,
             fontWeight: FontWeight.bold,
           ),
         ),
@@ -87,20 +83,21 @@ class _ProductListScreenState extends State<ProductListScreen> {
               },
               decoration: InputDecoration(
                 hintText: "Buscar producto...",
-                prefixIcon: const Icon(Icons.search, color: Color(0xff626762)),
+                prefixIcon:
+                    Icon(Icons.search, color: AppConstants.textLightColor),
                 filled: true,
-                fillColor: const Color.fromARGB(255, 255, 255, 255),
+                fillColor: Colors.white,
                 contentPadding: const EdgeInsets.symmetric(
                   horizontal: 12,
                   vertical: 0,
                 ),
                 enabledBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xffb4debf)),
+                  borderSide: BorderSide(color: AppConstants.secondaryColor),
                 ),
                 focusedBorder: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
-                  borderSide: const BorderSide(color: Color(0xff626762)),
+                  borderSide: BorderSide(color: AppConstants.textLightColor),
                 ),
               ),
             ),
@@ -121,13 +118,14 @@ class _ProductListScreenState extends State<ProductListScreen> {
                     filter,
                     style: TextStyle(
                       color: isSelected
-                          ? Colors.white
-                          : const Color(0xff343b45),
+                          ? AppConstants.backgroundColor
+                          : AppConstants.textDarkColor,
                     ),
                   ),
                   selected: isSelected,
-                  selectedColor: const Color(0xff626762),
-                  backgroundColor: const Color(0xffd4e6d7),
+                  selectedColor: AppConstants.primaryColor,
+                  backgroundColor:
+                      AppConstants.secondaryColor.withOpacity(0.7),
                   onSelected: (_) {
                     setState(() {
                       _selectedFilter = filter;
@@ -154,7 +152,9 @@ class _ProductListScreenState extends State<ProductListScreen> {
                     decoration: BoxDecoration(
                       color: Colors.white,
                       borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: const Color(0xffd4e6d7)),
+                      border: Border.all(
+                        color: AppConstants.secondaryColor.withOpacity(0.6),
+                      ),
                       boxShadow: [
                         BoxShadow(
                           color: Colors.black.withOpacity(0.05),
@@ -180,10 +180,10 @@ class _ProductListScreenState extends State<ProductListScreen> {
                             errorBuilder: (_, __, ___) => Container(
                               width: 100,
                               height: 100,
-                              color: const Color(0xffd4e6d7),
-                              child: const Icon(
+                              color: AppConstants.secondaryColor,
+                              child: Icon(
                                 Icons.image,
-                                color: Color(0xff626762),
+                                color: AppConstants.textLightColor,
                               ),
                             ),
                           ),
@@ -198,18 +198,18 @@ class _ProductListScreenState extends State<ProductListScreen> {
                               children: [
                                 Text(
                                   p.name,
-                                  style: const TextStyle(
+                                  style: TextStyle(
                                     fontWeight: FontWeight.bold,
                                     fontSize: 16,
-                                    color: Color(0xff343b45),
+                                    color: AppConstants.textDarkColor,
                                   ),
                                   overflow: TextOverflow.ellipsis,
                                 ),
                                 Text(
                                   p.category,
-                                  style: const TextStyle(
+                                  style: TextStyle(
                                     fontSize: 13,
-                                    color: Color(0xff626762),
+                                    color: AppConstants.textLightColor,
                                   ),
                                 ),
                                 const SizedBox(height: 4),
@@ -233,8 +233,8 @@ class _ProductListScreenState extends State<ProductListScreen> {
                                 const SizedBox(height: 4),
                                 Text(
                                   "\$${p.price.toStringAsFixed(0)}",
-                                  style: const TextStyle(
-                                    color: Colors.green,
+                                  style: TextStyle(
+                                    color: AppConstants.primaryColor,
                                     fontWeight: FontWeight.bold,
                                     fontSize: 15,
                                   ),
@@ -250,7 +250,7 @@ class _ProductListScreenState extends State<ProductListScreen> {
                             p.status,
                             style: TextStyle(
                               color: p.status.toLowerCase() == "activo"
-                                  ? Colors.green
+                                  ? AppConstants.primaryColor
                                   : Colors.red,
                               fontWeight: FontWeight.w600,
                             ),

--- a/movile/kajamart_movile/lib/admin/services/navigation_service.dart
+++ b/movile/kajamart_movile/lib/admin/services/navigation_service.dart
@@ -5,6 +5,7 @@ import 'package:kajamart_movile/admin/models/provider.dart' as model;
 import '../models/product.dart';
 import '../services/product_service.dart';
 import '../services/provider_service.dart';
+import '../constants/app_constants.dart';
 import '../screens/product_list.dart';
 import '../screens/product_batches.dart';
 import '../screens/product_detail.dart';
@@ -75,14 +76,14 @@ class NavigationService {
 
   static Widget _buildUnderConstructionScreen(int? sectionIndex) {
     return Scaffold(
-      backgroundColor: const Color(0xffe8e5dc),
+      backgroundColor: AppConstants.backgroundColor,
       body: Center(
         child: Text(
           'Sección ${sectionIndex ?? 'desconocida'} en construcción',
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 18,
             fontWeight: FontWeight.w500,
-            color: Color(0xff343b45),
+            color: AppConstants.textDarkColor,
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- update the admin color constants to match the client's white background and bright green primary
- refresh admin screens to consume the new palette and remove hard-coded legacy colors
- ensure navigation placeholders and main shell use the shared theme colors

## Testing
- Not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68e211e74604832098c85198a1177a47