### PR TITLE
Remove provider images from admin screens

### DIFF
--- a/movile/kajamart_movile/lib/admin/screens/provider_detail.dart
+++ b/movile/kajamart_movile/lib/admin/screens/provider_detail.dart
@@ -108,71 +108,43 @@ class _ProviderDetailScreenState extends State<ProviderDetailScreen> {
           ),
         ],
       ),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Imagen del proveedor
-          ClipRRect(
-            borderRadius: BorderRadius.circular(8),
-            child: Image.network(
-              provider.imageUrl ?? 'https://via.placeholder.com/300x200?text=No+Image',
-              width: 80,
-              height: 80,
-              fit: BoxFit.cover,
-              errorBuilder: (_, __, ___) => Container(
-                width: 80,
-                height: 80,
-                color: AppConstants.secondaryColor.withOpacity(0.3),
-                child: Icon(
-                  Icons.business,
-                  color: AppConstants.textLightColor,
-                  size: 40,
-                ),
-              ),
+          Text(
+            provider.name,
+            style: TextStyle(
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+              color: AppConstants.textDarkColor,
             ),
           ),
-          const SizedBox(width: 16),
-          // Información básica
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  provider.name,
-                  style: TextStyle(
-                    fontSize: 20,
-                    fontWeight: FontWeight.bold,
-                    color: AppConstants.textDarkColor,
-                  ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  'NIT: ${provider.nit}',
-                  style: TextStyle(
-                    fontSize: 14,
-                    color: AppConstants.textLightColor,
-                  ),
-                ),
-                const SizedBox(height: 8),
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                  decoration: BoxDecoration(
-                    color: Color(provider.status.colorValue).withOpacity(0.1),
-                    borderRadius: BorderRadius.circular(8),
-                    border: Border.all(
-                      color: Color(provider.status.colorValue),
-                      width: 1,
-                    ),
-                  ),
-                  child: Text(
-                    provider.status.displayName,
-                    style: TextStyle(
-                      color: Color(provider.status.colorValue),
-                      fontWeight: FontWeight.w600,
-                      fontSize: 12,
-                    ),
-                  ),
-                ),
-              ],
+          const SizedBox(height: 4),
+          Text(
+            'NIT: ${provider.nit}',
+            style: TextStyle(
+              fontSize: 14,
+              color: AppConstants.textLightColor,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: Color(provider.status.colorValue).withOpacity(0.1),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(
+                color: Color(provider.status.colorValue),
+                width: 1,
+              ),
+            ),
+            child: Text(
+              provider.status.displayName,
+              style: TextStyle(
+                color: Color(provider.status.colorValue),
+                fontWeight: FontWeight.w600,
+                fontSize: 12,
+              ),
             ),
           ),
         ],

--- a/movile/kajamart_movile/lib/admin/screens/provider_list.dart
+++ b/movile/kajamart_movile/lib/admin/screens/provider_list.dart
@@ -159,33 +159,10 @@ class _ProviderListScreenState extends State<ProviderListScreen> {
                     child: Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
-                        // Imagen
-                        ClipRRect(
-                          borderRadius: const BorderRadius.only(
-                            topLeft: Radius.circular(12),
-                            bottomLeft: Radius.circular(12),
-                          ),
-                          child: Image.network(
-                            provider.imageUrl ?? 'https://via.placeholder.com/300x200?text=No+Image',
-                            width: 100,
-                            height: 100,
-                            fit: BoxFit.cover,
-                            errorBuilder: (_, __, ___) => Container(
-                              width: 100,
-                              height: 100,
-                              color: AppConstants.secondaryColor.withOpacity(0.3),
-                              child: Icon(
-                                Icons.business,
-                                color: AppConstants.textLightColor,
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
                         // Información
                         Expanded(
                           child: Padding(
-                            padding: const EdgeInsets.symmetric(vertical: 8),
+                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                             child: Column(
                               crossAxisAlignment: CrossAxisAlignment.start,
                               children: [


### PR DESCRIPTION
## Summary
- remove the provider image previews from the admin list view and keep the textual information
- update the provider detail header to exclude the photo while retaining the rest of the data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e30c90a94c8320873ff999cbcf8702