### PR TITLE
Adjust admin home app bar for provider screen

### DIFF
--- a/movile/kajamart_movile/lib/admin/screens/admin_home.dart
+++ b/movile/kajamart_movile/lib/admin/screens/admin_home.dart
@@ -47,17 +47,7 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppConstants.backgroundColor,
-      appBar: AppBar(
-        title: Text(
-          _titles[_selectedIndex],
-          style: const TextStyle(
-            color: Colors.white,
-            fontWeight: FontWeight.bold,
-          ),
-        ),
-        backgroundColor: AppConstants.primaryColor,
-        elevation: 0,
-      ),
+      appBar: _buildAppBar(),
       body: _buildScreenContent(),
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _selectedIndex,
@@ -104,6 +94,26 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
           ),
         ],
       ),
+    );
+  }
+
+  PreferredSizeWidget? _buildAppBar() {
+    const screensWithOwnAppBar = {0, 1, 5};
+
+    if (screensWithOwnAppBar.contains(_selectedIndex)) {
+      return null;
+    }
+
+    return AppBar(
+      title: Text(
+        _titles[_selectedIndex],
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      backgroundColor: AppConstants.primaryColor,
+      elevation: 0,
     );
   }
 


### PR DESCRIPTION
## Summary
- hide the main admin app bar when navigating to screens that already provide their own header

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e3171fbd608320bed92822c6780ee2