### PR TITLE
chore(container): actualizar imágenes Alpine para corregir CVEs de libpng/zlib

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:20-alpine3.22
 
 WORKDIR /app
 

--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -1,5 +1,5 @@
 # Build
-FROM docker.io/library/node:20-alpine AS build
+FROM docker.io/library/node:20-alpine3.22 AS build
 WORKDIR /app
 
 COPY package*.json ./
@@ -9,7 +9,7 @@ COPY . .
 RUN npm run build
 
 # Serve
-FROM docker.io/library/nginx:alpine
+FROM docker.io/library/nginx:1.29-alpine3.22
 
 # Para React Router / SPA
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   frontend:
-    image: node:20-alpine
+    image: node:20-alpine3.22
     working_dir: /app
     ports:
       - "5173:5173"


### PR DESCRIPTION
### Motivation
- Actualizar las imágenes base Alpine usadas por el frontend para remediar CVEs en `libpng` y `zlib` reportados, minimizando el impacto en la aplicación.

### Description
- Cambios mínimos en imágenes: `frontend/Dockerfile` (`node:20-alpine` → `node:20-alpine3.22`), `frontend/Dockerfile.prod` (build: `node:20-alpine` → `node:20-alpine3.22`, runtime: `nginx:alpine` → `nginx:1.29-alpine3.22`), y `frontend/docker-compose.yml` (`image: node:20-alpine` → `node:20-alpine3.22`).

### Testing
- Ejecutados: `npm run build` en `frontend` (exitoso), `npm test -- --runInBand` en `frontend` (falló por tests preexistentes no relacionados con el cambio), y `npx eslint .` en `frontend` (falló por errores/lints preexistentes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d7ca0ed3648327899c310637cfd146)